### PR TITLE
Drupal 10 requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
         "drupal-updater"
     ],
     "require": {
-        "symfony/console": "^4 || ^5",
-        "symfony/process": "^4 || ^5",
+        "symfony/console": "^4 || ^5 || ^6",
+        "symfony/process": "^4 || ^5 || ^6",
         "drush/drush": "^10 || ^11",
         "davidrjonas/composer-lock-diff": "^1.7"
     },


### PR DESCRIPTION
Drupal 10 requires `symfony/console:^6` and `symfony/process:^6`

```
drupal/core                     10.0.3   requires  symfony/console (^6.2)                                                           
drupal/core-recommended         10.0.3   requires  symfony/console (~v6.2.5)

drupal/core                10.0.3       requires  symfony/process (^6.2)                          
drupal/core-recommended    10.0.3       requires  symfony/process (~v6.2.5)
```