### PR TITLE
Drush 13 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "symfony/console": "^4 || ^5 || ^6",
         "symfony/process": "^4 || ^5 || ^6",
-        "drush/drush": "^10 || ^11 || ^12 || ^13",
+        "drush/drush": ">=10",
         "davidrjonas/composer-lock-diff": "^1.7"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "symfony/console": "^4 || ^5 || ^6",
         "symfony/process": "^4 || ^5 || ^6",
-        "drush/drush": "^10 || ^11 || ^12",
+        "drush/drush": "^10 || ^11 || ^12 || ^13",
         "davidrjonas/composer-lock-diff": "^1.7"
     },
     "authors": [


### PR DESCRIPTION
The updater seems to work fine with Drush 13, but it's disallowed by composer.json. This adds support for Drush 13. 